### PR TITLE
Add tests to R CMD check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,6 @@ Suggests:
     lmerTest,
     psych,
     afex,
-    emmeans
+    emmeans,
+    MASS,
+    nlme

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Encoding: UTF-8
 RoxygenNote: 6.1.1
 LazyData: true
 Suggests: 
-    testthat,
+    testthat (>= 2.1.0),
     lme4,
     lmerTest,
     psych,

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(tidystats)
+
+test_check("tidystats")

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -24,6 +24,7 @@ test_that("generalized linear models with a poisson family work", {
 })
 
 test_that("generalized linear models with a gaussian family work", {
+  skip_if_not_installed("MASS")
   correct <- test_results[["glm_gaussian"]]
 
   utils::data(anorexia, package = "MASS")

--- a/tests/testthat/test-lme4.R
+++ b/tests/testthat/test-lme4.R
@@ -28,8 +28,8 @@ test_that("lme4's linear mixed models with uncorrelated terms work", {
 })
 
 test_that("lme4's linear mixed models with dummies work", {
+  skip_if_not_installed("nlme")
   correct <- test_results[["lme4_lme_dummies"]]
-
   data(Orthodont, package = "nlme")
   Orthodont$nsex <- as.numeric(Orthodont$Sex == "Male")
   Orthodont$nsexage <- with(Orthodont, nsex * age)

--- a/tests/testthat/test-lmerTest.R
+++ b/tests/testthat/test-lmerTest.R
@@ -28,8 +28,8 @@ test_that("lmerTest's linear mixed models with uncorrelated terms work", {
 })
 
 test_that("lmerTest's linear mixed models with dummies work", {
+  skip_if_not_installed("nlme")
   correct <- test_results[["lmerTest_lme_dummies"]]
-
   data(Orthodont, package = "nlme")
   Orthodont$nsex <- as.numeric(Orthodont$Sex == "Male")
   Orthodont$nsexage <- with(Orthodont, nsex * age)


### PR DESCRIPTION
The `testthat` testfiles are not run by `R CMD check`, while they should be. This patch makes sure they are run when `R CMD check` is run.

In addition, adding the tests to `R CMD check` uncovered some unstated package dependencies. This patch adds those packages to `DESCRIPTION` (as suggested packages) and makes sure the dependent tests are not run if the required packages are not installed (which is possible, because they are suggested).